### PR TITLE
Add SCM info for parent and dependencies to CFF

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3067,3 +3067,4 @@ references:
   license: Apache-2.0
   authors:
   - name: Kotlin Team
+repository-code: https://github.com/thomaskrause/cff-maven-plugin

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,7 @@ authors:
 - family-names: Druskat
   first-names: Stephan
   orcid: https://orcid.org/0000-0003-4925-7248
+repository-code: https://github.com/hexatomic/cff-maven-plugin
 references:
 - type: software
   title: AOP alliance (aopalliance)
@@ -23,6 +24,7 @@ references:
     email: kohsuke (dot) kawaguchi (at) sun (dot) com
   - name: Stephen Connolly
     email: stephen (dot) alan (dot) connolly (at) gmail (dot) com
+  repository-code: http://fisheye.codehaus.org/browse/mojo/tags/animal-sniffer-parent-1.14/animal-sniffer-annotations
 - type: software
   title: Apache Commons IO (commons-io)
   version: '2.5'
@@ -53,6 +55,7 @@ references:
     email: ggregory@apache.org
   - name: Kristian Rosenvold
     email: krosenvold@apache.org
+  repository-code: http://svn.apache.org/viewvc/commons/proper/io/tags/commons-io-2.5
 - type: software
   title: Apache Commons Lang (commons-lang3)
   version: 3.8.1
@@ -89,6 +92,7 @@ references:
     email: lguibert@apache.org
   - name: Rob Tompkins
     email: chtompki@apache.org
+  repository-code: https://git-wip-us.apache.org/repos/asf?p=commons-lang.git
 - type: software
   title: Apache Maven Shared Utils (maven-shared-utils)
   version: 3.2.1
@@ -231,6 +235,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-shared-utils/tree/maven-shared-utils-3.2.1
 - type: software
   title: 'Apache Maven Wagon :: API (wagon-provider-api)'
   version: 3.3.3
@@ -377,6 +382,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-wagon/tree/wagon-3.3.3/wagon-provider-api
 - type: software
   title: CDI APIs (cdi-api)
   version: '1.0'
@@ -387,6 +393,7 @@ references:
   - name: Shane Bryzak
   - name: David Allen
   - name: Nicklas Karlsson
+  repository-code: http://fisheye.jboss.org/browse/Weld/api/tags/1.0/build/tags/weld-parent-6/weld-api-bom/weld-api-parent/cdi-api
 - type: software
   title: Checker Qual (checker-compat-qual)
   version: 2.0.0
@@ -406,18 +413,21 @@ references:
     email: dbro@cs.washington.edu
   - name: Jonathan G. Burke
     email: jburke@cs.washington.edu
+  repository-code: https://github.com/typetools/checker-framework.git
 - type: software
   title: FindBugs-jsr305 (jsr305)
   version: 3.0.2
   license: Apache-2.0
   authors:
   - name: The FindBugs-jsr305 (jsr305) 3.0.2 Team
+  repository-code: https://code.google.com/p/jsr-305/
 - type: software
   title: Google Guice - Core Library (guice)
   version: 4.2.1
   license: Apache-2.0
   authors:
   - name: null
+  repository-code: https://github.com/google/guice/guice
 - type: software
   title: 'Guava: Google Core Libraries for Java (guava)'
   version: 25.1-android
@@ -425,18 +435,21 @@ references:
   authors:
   - name: Kevin Bourrillion
     email: kevinb@google.com
+  repository-code: https://github.com/google/guava/guava
 - type: software
   title: IntelliJ IDEA Annotations (annotations)
   version: '13.0'
   license: Apache-2.0
   authors:
   - name: JetBrains Team
+  repository-code: https://github.com/JetBrains/intellij-community
 - type: software
   title: J2ObjC Annotations (j2objc-annotations)
   version: '1.1'
   license: Apache-2.0
   authors:
   - name: The J2ObjC Annotations (j2objc-annotations) 1.1 Team
+  repository-code: http://svn.sonatype.org/spice/tags/oss-parent-7/j2objc-annotations
 - type: software
   title: JSON in Java (json)
   version: '20190722'
@@ -444,6 +457,7 @@ references:
   authors:
   - name: Douglas Crockford
     email: douglas@crockford.com
+  repository-code: https://github.com/douglascrockford/JSON-java.git
 - type: software
   title: JSR-250 Common Annotations for the JavaTM Platform (jsr250-api)
   version: '1.0'
@@ -597,6 +611,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-artifact
 - type: software
   title: Maven Artifact Resolver API (maven-resolver-api)
   version: 1.4.1
@@ -743,6 +758,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-resolver/tree/maven-resolver-1.4.1/maven-resolver-api
 - type: software
   title: Maven Artifact Resolver Implementation (maven-resolver-impl)
   version: 1.4.1
@@ -889,6 +905,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-resolver/tree/maven-resolver-1.4.1/maven-resolver-impl
 - type: software
   title: Maven Artifact Resolver Provider (maven-resolver-provider)
   version: 3.6.2
@@ -1035,6 +1052,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-resolver-provider
 - type: software
   title: Maven Artifact Resolver SPI (maven-resolver-spi)
   version: 1.4.1
@@ -1181,6 +1199,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-resolver/tree/maven-resolver-1.4.1/maven-resolver-spi
 - type: software
   title: Maven Artifact Resolver Utilities (maven-resolver-util)
   version: 1.4.1
@@ -1327,6 +1346,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven-resolver/tree/maven-resolver-1.4.1/maven-resolver-util
 - type: software
   title: Maven Builder Support (maven-builder-support)
   version: 3.6.2
@@ -1473,6 +1493,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-builder-support
 - type: software
   title: Maven Compat (maven-compat)
   version: 3.6.2
@@ -1619,6 +1640,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-compat
 - type: software
   title: Maven Core (maven-core)
   version: 3.6.2
@@ -1765,6 +1787,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-core
 - type: software
   title: Maven Model (maven-model)
   version: 3.6.2
@@ -1911,6 +1934,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-model
 - type: software
   title: Maven Model Builder (maven-model-builder)
   version: 3.6.2
@@ -2057,6 +2081,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-model-builder
 - type: software
   title: Maven Plugin API (maven-plugin-api)
   version: 3.6.2
@@ -2203,6 +2228,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-plugin-api
 - type: software
   title: Maven Plugin Tools Java 5 Annotations (maven-plugin-annotations)
   version: '3.4'
@@ -2336,6 +2362,7 @@ references:
     email: jruiz@apache.org
   - name: Kenney Westerhof
     email: kenney@apache.org
+  repository-code: http://svn.apache.org/viewvc/maven/plugin-tools/tags/maven-plugin-tools-3.4/maven-plugin-annotations
 - type: software
   title: Maven Repository Metadata Model (maven-repository-metadata)
   version: 3.6.2
@@ -2482,6 +2509,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-repository-metadata
 - type: software
   title: Maven Settings (maven-settings)
   version: 3.6.2
@@ -2628,6 +2656,7 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-settings
 - type: software
   title: Maven Settings Builder (maven-settings-builder)
   version: 3.6.2
@@ -2774,12 +2803,14 @@ references:
     email: trygvis@apache.org
   - name: Wendy Smoak
     email: wsmoak@apache.org
+  repository-code: https://github.com/apache/maven/tree/maven-3.6.2/maven-settings-builder
 - type: software
   title: Okio (okio)
   version: 2.2.2
   license: Apache-2.0
   authors:
   - name: Square, Inc.
+  repository-code: https://github.com/square/okio/
 - type: software
   title: 'Plexus :: Component Annotations (plexus-component-annotations)'
   version: 2.0.0
@@ -2834,6 +2865,7 @@ references:
     email: khmarbaise@apache.org
   - name: Michael Osipov
     email: 1983-01-06@gmx.net
+  repository-code: https://github.com/codehaus-plexus/plexus-containers/plexus-component-annotations
 - type: software
   title: 'Plexus Cipher: encryption/decryption Component (plexus-cipher)'
   version: '1.4'
@@ -2841,6 +2873,7 @@ references:
   authors:
   - name: 'The Plexus Cipher: encryption/decryption Component (plexus-cipher) 1.4
       Team'
+  repository-code: http://svn.sonatype.org/spice/tags/plexus-cipher-1.4
 - type: software
   title: Plexus Classworlds (plexus-classworlds)
   version: 2.6.0
@@ -2895,6 +2928,7 @@ references:
     email: khmarbaise@apache.org
   - name: Michael Osipov
     email: 1983-01-06@gmx.net
+  repository-code: http://github.com/codehaus-plexus/plexus-classworlds/tree/plexus-classworlds-2.6.0/
 - type: software
   title: Plexus Common Utilities (plexus-utils)
   version: 3.2.1
@@ -2949,6 +2983,7 @@ references:
     email: khmarbaise@apache.org
   - name: Michael Osipov
     email: 1983-01-06@gmx.net
+  repository-code: http://github.com/codehaus-plexus/plexus-utils
 - type: software
   title: Plexus Interpolation API (plexus-interpolation)
   version: '1.25'
@@ -3003,12 +3038,14 @@ references:
     email: khmarbaise@apache.org
   - name: Michael Osipov
     email: 1983-01-06@gmx.net
+  repository-code: http://github.com/codehaus-plexus/plexus-interpolation/tree/plexus-interpolation-1.25/
 - type: software
   title: Plexus Security Dispatcher Component (plexus-sec-dispatcher)
   version: '1.4'
   license: Apache-2.0
   authors:
   - name: The Plexus Security Dispatcher Component (plexus-sec-dispatcher) 1.4 Team
+  repository-code: http://svn.sonatype.org/spice/tags/plexus-sec-dispatcher-1.4
 - type: software
   title: SLF4J API Module (slf4j-api)
   version: 1.7.25
@@ -3016,6 +3053,7 @@ references:
   authors:
   - name: Ceki Gulcu
     email: ceki@qos.ch
+  repository-code: https://github.com/qos-ch/slf4j/slf4j-api
 - type: software
   title: SnakeYAML Engine (snakeyaml-engine)
   version: '2.0'
@@ -3025,46 +3063,53 @@ references:
     email: public.somov@gmail.com
   - name: Alexander Maslov
     email: alexander.maslov@gmail.com
+  repository-code: https://bitbucket.org/asomov/snakeyaml-engine/src
 - type: software
   title: error-prone annotations (error_prone_annotations)
   version: 2.1.3
   license: Apache-2.0
   authors:
   - name: The error-prone annotations (error_prone_annotations) 2.1.3 Team
+  repository-code: https://github.com/google/error-prone/error_prone_annotations
 - type: software
   title: javax.inject (javax.inject)
   version: '1'
   license: Apache-2.0
   authors:
   - name: The javax.inject (javax.inject) 1 Team
+  repository-code: http://code.google.com/p/atinject/source/checkout
 - type: software
   title: okhttp (okhttp)
   version: 4.2.2
   license: Apache-2.0
   authors:
   - name: Square, Inc.
+  repository-code: https://github.com/square/okhttp
 - type: software
   title: org.eclipse.sisu.inject (org.eclipse.sisu.inject)
   version: 0.3.3
   license: EPL-1.0
   authors:
   - name: The org.eclipse.sisu.inject (org.eclipse.sisu.inject) 0.3.3 Team
+  repository-code: http://git.eclipse.org/c/sisu/org.eclipse.sisu.inject.git/tree/org.eclipse.sisu.inject/
 - type: software
   title: org.eclipse.sisu.plexus (org.eclipse.sisu.plexus)
   version: 0.3.3
   license: EPL-1.0
   authors:
   - name: The org.eclipse.sisu.plexus (org.eclipse.sisu.plexus) 0.3.3 Team
+  repository-code: http://git.eclipse.org/c/sisu/org.eclipse.sisu.plexus.git/tree/org.eclipse.sisu.plexus/
 - type: software
   title: org.jetbrains.kotlin:kotlin-stdlib (kotlin-stdlib)
   version: 1.3.50
   license: Apache-2.0
   authors:
   - name: Kotlin Team
+  repository-code: https://github.com/JetBrains/kotlin
 - type: software
   title: org.jetbrains.kotlin:kotlin-stdlib-common (kotlin-stdlib-common)
   version: 1.3.50
   license: Apache-2.0
   authors:
   - name: Kotlin Team
-repository-code: https://github.com/thomaskrause/cff-maven-plugin
+  repository-code: https://github.com/JetBrains/kotlin

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,8 @@ references:
   title: AOP alliance (aopalliance)
   version: '1.0'
   license: OTHER
+  authors:
+  - name: The AOP alliance (aopalliance) 1.0 Team
 - type: software
   title: Animal Sniffer Annotations (animal-sniffer-annotations)
   version: '1.14'
@@ -405,6 +407,8 @@ references:
   title: FindBugs-jsr305 (jsr305)
   version: 3.0.2
   license: Apache-2.0
+  authors:
+  - name: The FindBugs-jsr305 (jsr305) 3.0.2 Team
 - type: software
   title: Google Guice - Core Library (guice)
   version: 4.2.1
@@ -428,6 +432,8 @@ references:
   title: J2ObjC Annotations (j2objc-annotations)
   version: '1.1'
   license: Apache-2.0
+  authors:
+  - name: The J2ObjC Annotations (j2objc-annotations) 1.1 Team
 - type: software
   title: JSON in Java (json)
   version: '20190722'
@@ -439,6 +445,9 @@ references:
   title: JSR-250 Common Annotations for the JavaTM Platform (jsr250-api)
   version: '1.0'
   license: NOASSERTION
+  authors:
+  - name: The JSR-250 Common Annotations for the JavaTM Platform (jsr250-api) 1.0
+      Team
 - type: software
   title: Maven Artifact (maven-artifact)
   version: 3.6.2
@@ -2826,6 +2835,9 @@ references:
   title: 'Plexus Cipher: encryption/decryption Component (plexus-cipher)'
   version: '1.4'
   license: Apache-2.0
+  authors:
+  - name: 'The Plexus Cipher: encryption/decryption Component (plexus-cipher) 1.4
+      Team'
 - type: software
   title: Plexus Classworlds (plexus-classworlds)
   version: 2.6.0
@@ -2992,6 +3004,8 @@ references:
   title: Plexus Security Dispatcher Component (plexus-sec-dispatcher)
   version: '1.4'
   license: Apache-2.0
+  authors:
+  - name: The Plexus Security Dispatcher Component (plexus-sec-dispatcher) 1.4 Team
 - type: software
   title: SLF4J API Module (slf4j-api)
   version: 1.7.25
@@ -3012,10 +3026,14 @@ references:
   title: error-prone annotations (error_prone_annotations)
   version: 2.1.3
   license: Apache-2.0
+  authors:
+  - name: The error-prone annotations (error_prone_annotations) 2.1.3 Team
 - type: software
   title: javax.inject (javax.inject)
   version: '1'
   license: Apache-2.0
+  authors:
+  - name: The javax.inject (javax.inject) 1 Team
 - type: software
   title: okhttp (okhttp)
   version: 4.2.2
@@ -3026,10 +3044,14 @@ references:
   title: org.eclipse.sisu.inject (org.eclipse.sisu.inject)
   version: 0.3.3
   license: EPL-1.0
+  authors:
+  - name: The org.eclipse.sisu.inject (org.eclipse.sisu.inject) 0.3.3 Team
 - type: software
   title: org.eclipse.sisu.plexus (org.eclipse.sisu.plexus)
   version: 0.3.3
   license: EPL-1.0
+  authors:
+  - name: The org.eclipse.sisu.plexus (org.eclipse.sisu.plexus) 0.3.3 Team
 - type: software
   title: org.jetbrains.kotlin:kotlin-stdlib (kotlin-stdlib)
   version: 1.3.50

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,9 @@ title: cff Maven Plugin
 version: 0.1.0-SNAPSHOT
 authors:
 - name: Thomas Krause
+- family-names: Druskat
+  first-names: Stephan
+  orcid: https://orcid.org/0000-0003-4925-7248
 references:
 - type: software
   title: AOP alliance (aopalliance)

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,11 @@
       <email>krauseto@hu-berlin.de</email>
       <organization>Humboldt Universität zu Berlin</organization>
     </developer>
+    <developer>
+      <name>Stephan Druskat</name>
+      <email>mail@sdruskat.net</email>
+      <organization>Friedrich Schiller University Jena</organization>
+    </developer>
   </developers>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,10 @@
       <organization>Friedrich Schiller University Jena</organization>
     </developer>
   </developers>
+  
+  <scm>
+  	<url>https://github.com/hexatomic/cff-maven-plugin</url>
+  </scm>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
+++ b/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
+++ b/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
@@ -146,9 +146,11 @@ public class CreateFromDependenciesMojo extends AbstractMojo {
             author.put("name", dev.getName());
             authors.add(author);
         }
+        // If no authors are specified, use generic fallback author info
         if (authors.isEmpty()) {
+        	getLog().info("No author info found for this project. Creating fallback information.");
             HashMap<String, Object> author = new HashMap<>();
-            author.put("name", "The " + project.getName() + " " + project.getVersion() + " Team");
+            author.put("name", "The " + cff.get("title") + " " + cff.get("version") + " Team");
             authors.add(author);
         }
         cff.putIfAbsent("authors", authors);
@@ -245,8 +247,12 @@ public class CreateFromDependenciesMojo extends AbstractMojo {
                     author.put("name", name);
                     authorList.add(author);
                 }
-                if (!authorList.isEmpty()) {
-                    reference.put("authors", authorList);
+                // If no authors are specified, use generic fallback author info
+                if (authorList.isEmpty()) {
+                	getLog().info("No author info found for P2 artifact " + artifact.getId() + ". Creating fallback information.");
+                    HashMap<String, Object> author = new LinkedHashMap<>();
+                    author.put("name", "The " + reference.get("title") + " " + reference.get("version") + " Team");
+                    authorList.add(author);
                 }
             }
         }
@@ -352,12 +358,17 @@ public class CreateFromDependenciesMojo extends AbstractMojo {
             }
             authorList.add(author);
         }
-        if (!authorList.isEmpty()) {
-            reference.put("authors", authorList);
+        // If no authors are specified, use generic fallback author info
+        if (authorList.isEmpty()) {
+        	getLog().info("No author info found for Maven artifact " + artifact.getArtifactId() + ". Creating fallback information.");
+        	Map<String, Object> author = new LinkedHashMap<>();
+            author.put("name", "The " + reference.get("title") + " " + reference.get("version") + " Team");
+            authorList.add(author);
         }
+        reference.put("authors", authorList);
     }
 
-    private Optional<RemoteLicenseInformation> queryLicenseFromClearlyDefined(Artifact artifact) {
+	private Optional<RemoteLicenseInformation> queryLicenseFromClearlyDefined(Artifact artifact) {
         // query the REST API of ClearlyDefined
         // https://api.clearlydefined.io/api-docs/
         List<String> patterns = new LinkedList<>();

--- a/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
+++ b/src/main/java/org/corpus_tools/cffmaven/CreateFromDependenciesMojo.java
@@ -147,9 +147,12 @@ public class CreateFromDependenciesMojo extends AbstractMojo {
             author.put("name", dev.getName());
             authors.add(author);
         }
-        if (!authors.isEmpty()) {
-            cff.putIfAbsent("authors", authors);
+        if (authors.isEmpty()) {
+            HashMap<String, Object> author = new HashMap<>();
+            author.put("name", "The " + project.getName() + " " + project.getVersion() + " Team");
+            authors.add(author);
         }
+        cff.putIfAbsent("authors", authors);
 
         // get existing references and add new ones to the list
         List<Map<String, Object>> references = mapExistingReferences(cff.get("references"));


### PR DESCRIPTION
This PR adds functionality to add SCM URLs for the parent project and dependencies to the CFF file.

Note that this doesn't yet work for P2-ified dependencies for resolution issues.

Fixes #2.
Based on #10. **Please merge #10 first.**